### PR TITLE
Changes to atmos object, T_surf timestepping, and some quality-of-life updates

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -3,16 +3,11 @@
 
 1. Install dependencies
 
-    * Setup a conda environment
 
-        * Install conda
-            Download the appropriate Miniconda installer from their website
-            https://docs.conda.io/en/latest/miniconda.html#id36
+    * MacOS: Ensure installation of command line developer tools
+        * Open Xcode application and install
+        * Type `xcode-select --install`
 
-        * Create a conda environment for PROTEUS
-            `conda create -n aeolus python=3.10.9`    
-            `conda activate aeolus`
-            
     * Install FORTRAN NetCDF library via the most appropriate method for you
         * `brew install netcdf`    
         * `brew install netcdf-fortran`     
@@ -21,9 +16,29 @@
         OR     
         * `sudo apt install libnetcdff-dev`
     
-    * Install Python libraries:
-        * `conda install netcdf4 matplotlib numpy pandas scipy seaborn natsort`
-        * `conda install -c conda-forge f90nml`
+    * Setup a Python environment:
+        * Option A: Using the `Anaconda` package manager (careful, probably breaks on ARM machines/newer Macs)
+            * Install `conda`:
+                * Download the appropriate Miniconda installer from their website
+            https://docs.conda.io/en/latest/miniconda.html#id36
+                * Create a conda environment for PROTEUS:
+                * `conda create -n aeolus python=3.10.9`    
+                * `conda activate aeolus`
+            * `conda install netcdf4 matplotlib numpy pandas scipy sympy natsort`
+            * `conda install -c conda-forge f90nml`
+        * Option B: using the `brew` package manager (*recommended*)
+            * Delete all traces of Anaconda package manager from your system and switch to a different Python environment, for example brew/pip
+            * Follow the steps at https://docs.anaconda.com/free/anaconda/install/uninstall/
+            * Delete all Anaconda-related entries from your .bash_profile (Intel) or .zshrc (ARM)
+            * Install Python via `brew`: 
+                * `brew install python`
+                * Update to the latest stable version: `brew upgrade python`
+                * Install `tkinter`: `brew install python-tk@3.11`
+                * Refresh your shell / `source ~/.zsrhrc` (ARM) / `source ~/.bash_profile` (Intel)
+                * Install all necessary packages: `pip3 install matplotlib pandas netcdf4 matplotlib numpy pandas scipy sympy natsort`
+            * Make the new Python version the system default (check what `brew` tells you during/after the `brew install python` step):
+                * ARM: `export PATH="/opt/homebrew/opt/python/libexec/bin:$PATH"`
+                * Intel: `export PATH="/usr/local/opt/python/libexec/bin:$PATH"`
 
     * *Optionally* register your public SSH key with Github:
         * Generate key with `ssh-keygen -t rsa`
@@ -36,8 +51,9 @@
         * Contact: TL, MH, RB
 
     * Radiation transport: **SOCRATES** 
-        * URL: https://code.metoffice.gov.uk/trac/socrates
+        * Main development URL: https://code.metoffice.gov.uk/trac/socrates
         * Contact: james.manners@metoffice.gov.uk
+        * Obtain the SOCRATES source code from: https://simplex.giss.nasa.gov/gcm/ROCKE-3D/ (Latest released version of SOCRATES code)
         * Latest tested version: *socrates_2211.tar.xz*
 
 3. Setup codes and modules in the following order (ignore their individual README files)
@@ -45,17 +61,19 @@
     1. Download AEOLUS (*AEOLUS, SPIDER, VULCAN*)
         * `git clone  git@github.com:FormingWorlds/AEOLUS.git`
 
-    2. Enter into AEOLUS folder
-        * `cd AEOLUS`
-
-    3. Extract SOCRATES archive to the correct location
-        * `cd rad_trans/socrates_code/`
+    2. Download and extract the SOCRATES archive to the correct location
+        * `cd AEOLUS/rad_trans/socrates_code/`
+        * `curl -L -o ../socrates_2211.tar.xz https://www.dropbox.com/sh/ixefmrbg7c94jlj/AAChibnZU9PRi8pXdVxVbdj3a/socrates_2211.tar.xz?dl=1`
         * `tar --strip-components 1 -xvf PATH_TO_ARCHIVE -C ./`
         * `cp -f ../build_code_modified build_code`
 
     4. Overwrite the `Mk_cmd` file with the right setup for your machine
         * `cp -rf ../Mk_cmd_SYSTEM make/Mk_cmd`    
-        Options are: *Mk_cmd_MAC_INTEL*, *Mk_cmd_MAC_APPLESILICON*, *Mk_cmd_AOPP_CLUSTER*.    
+        * Options are:
+            * `cp -rf ../Mk_cmd_MAC_INTEL make/Mk_cmd`
+            * `cp -rf ../Mk_cmd_MAC_APPLESILICON make/Mk_cmd`
+            * `cp -rf ../Mk_cmd_AOPP_CLUSTER make/Mk_cmd`
+            
         The command `nf-config` might be helpful if none of these options work for you.
 
     5. Setup SOCRATES 

--- a/SocRadConv.py
+++ b/SocRadConv.py
@@ -47,7 +47,7 @@ if __name__ == "__main__":
     pl_mass       = 5.972e24            # kg, planet mass
 
     # Boundary conditions for pressure & temperature
-    T_surf        = 310.0                # K
+    T_surf        = 1000.0                # K
     P_top         = 1.0                  # Pa
 
     # Define volatiles by mole fractions
@@ -103,7 +103,7 @@ if __name__ == "__main__":
     pure_steam_adj = False
 
     # Tropopause calculation
-    trppD = True   # Calculate dynamically?
+    trppD = False   # Calculate dynamically?
     trppT = 70.0     # Fixed tropopause value if not calculated dynamically
     
     # Surface temperature time-stepping
@@ -136,9 +136,13 @@ if __name__ == "__main__":
     atm_dry, atm_moist = RadConvEqm(dirs, time, atm, standalone=True, cp_dry=cp_dry, trppD=trppD, calc_cf=calc_cf, rscatter=rscatter, pure_steam_adj=pure_steam_adj, surf_dt=surf_dt, cp_surf=cp_surf, mix_coeff_atmos=mix_coeff_atmos, mix_coeff_surf=mix_coeff_surf) 
     
     # Plot abundances w/ TP structure
-    ga.plot_adiabats(atm_moist)
+    if (cp_dry):
+        ga.plot_adiabats(atm_dry,filename="output/dry_ga.pdf")
+        atm_dry.write_PT(filename="output/dry_pt.tsv")
 
-    atm_moist.write_PT()
+    ga.plot_adiabats(atm_moist,filename="output/moist_ga.pdf")
+    atm_moist.write_PT(filename="output/moist_pt.tsv")
+
 
     end = t.time()
     print("Runtime:", round(end - start,2), "s")

--- a/SocRadConv.py
+++ b/SocRadConv.py
@@ -73,6 +73,7 @@ if __name__ == "__main__":
     #             }
     # vol_partial = {}
 
+    # OR:
     # Define volatiles by partial pressures
     P_surf = 0.0
     vol_mixing = {}
@@ -108,7 +109,7 @@ if __name__ == "__main__":
     
     # Surface temperature time-stepping
     surf_dt = False
-    cp_dry = True
+    cp_dry = False
     # Options activated by surf_dt
     cp_surf = 1e5         # Heat capacity of the ground [J.kg^-1.K^-1]
     mix_coeff_atmos = 1e6 # mixing coefficient of the atmosphere [s]

--- a/SocRadConv.py
+++ b/SocRadConv.py
@@ -47,8 +47,8 @@ if __name__ == "__main__":
     pl_mass       = 5.972e24            # kg, planet mass
 
     # Boundary conditions for pressure & temperature
-    T_surf        = 1000.0                # K
-    P_top         = 1.0                  # Pa
+    T_surf        = 300.0                # K
+    P_top         = 10.0                  # Pa
 
     # Define volatiles by mole fractions
     # P_surf       = 50 * 1e5
@@ -108,7 +108,7 @@ if __name__ == "__main__":
     
     # Surface temperature time-stepping
     surf_dt = False
-    cp_dry = False
+    cp_dry = True
     # Options activated by surf_dt
     cp_surf = 1e5         # Heat capacity of the ground [J.kg^-1.K^-1]
     mix_coeff_atmos = 1e6 # mixing coefficient of the atmosphere [s]

--- a/clearsocrates.sh
+++ b/clearsocrates.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Script to delete socrates files if they happen to be left over
+rm profile.*
+rm radiation_code.lock
+rm currentsw.*

--- a/modules/compute_moist_adiabat.py
+++ b/modules/compute_moist_adiabat.py
@@ -15,7 +15,25 @@ from modules.set_stratosphere import set_stratosphere
 import utils.GeneralAdiabat as ga # Moist adiabat with multiple condensibles
 import utils.SocRadModel as SocRadModel
 
-def compute_moist_adiabat(atm, dirs, standalone, trpp, calc_cf=False, rscatter=False):
+def compute_moist_adiabat(atm, dirs, standalone, trppD, calc_cf=False, rscatter=False):
+    """Compute moist adiabat case
+
+    Parameters
+    ----------
+        atm : atmos
+            Atmosphere object from atmosphere_column.py
+        dirs : dict
+            Named directories
+        standalone : bool
+            Running AEOLUS as standalone code?
+        trppD : bool 
+            Calculate tropopause dynamically?
+        calc_cf : bool
+            Calculate contribution function?
+        rscatter : bool
+            Include Rayleigh scattering?
+            
+    """
 
     atm_moist = copy.deepcopy(atm)
 
@@ -28,10 +46,11 @@ def compute_moist_adiabat(atm, dirs, standalone, trpp, calc_cf=False, rscatter=F
     if standalone == True:
         print("w/o stratosphere (net, OLR):", str(round(atm_moist.net_flux[0], 3)), str(round(atm_moist.LW_flux_up[0], 3)), "W/m^2")
 
-    if trpp == True:
+    # Calculate tropopause dynamically
+    if (trppD == True) or ( (trppD == False) and (atm_moist.trppT > 0.0) ):
       
         # Find tropopause index
-        atm_moist = find_tropopause(atm_moist)
+        atm_moist = find_tropopause(atm_moist,trppD)
 
         # Reset stratosphere temperature and abundance levels
         atm_moist = set_stratosphere(atm_moist)

--- a/modules/dry_adiabat_timestep.py
+++ b/modules/dry_adiabat_timestep.py
@@ -29,14 +29,14 @@ def compute_dry_adiabat(atm, dirs, standalone, calc_cf=False, rscatter=False, pu
     dT_max      = 20.  # K, Maximum temperature change per radiation step
     T_floor     = 10.  # K, Temperature floor to prevent SOCRATES crash
 
-    # print("atm.toa_heating in compute_dry_adiabat = ", atm.toa_heating)
+    print("atm.toa_heating in compute_dry_adiabat = ", atm.toa_heating)
     # Build general adiabat structure
     atm                 = ga.general_adiabat(copy.deepcopy(atm))
-    # print("atm.toa_heating in compute_dry_adiabat = ", atm.toa_heating)
+    print("atm.toa_heating in compute_dry_adiabat = ", atm.toa_heating)
 
     # Copy moist pressure arrays for dry adiabat
     atm_dry             = dry_adiabat_atm(atm)
-    # print("atm_dry.toa_heating in compute_dry_adiabat = ", atm_dry.toa_heating)
+    print("atm_dry.toa_heating in compute_dry_adiabat = ", atm_dry.toa_heating)
 
     # Initialise previous OLR and TOA heating to zero
     PrevOLR_dry         = 0.

--- a/modules/find_tropopause.py
+++ b/modules/find_tropopause.py
@@ -6,14 +6,25 @@ Created on Mon Jan 23 11:59:40 2023
 @authors: 
 Tim Lichtenberg (TL)    
 Ryan Boukrouche (RB)
+Harrison Nicholls (HN)
 """
 
 import numpy as np
 
-def find_tropopause(atm_moist):
+def find_tropopause(atm_moist, dynamic: bool):
+    """Computes tropopause location via two methods: dynamically based on heating rates, or by a set temperature value.
+
+    Parameters
+    ----------
+        atm_moist : atmos
+            Atmosphere (moist) object from atmosphere_column.py
+        dynamic : bool
+            Calculate dynamically with heating rates? If not, use fixed value of trppT.
+            
+    """
 
     # Heating criterion
-    if atm_moist.trppT == 0:
+    if dynamic:
 
         print("TROPOPAUSE SET BY HEATING")
 
@@ -82,14 +93,11 @@ def find_tropopause(atm_moist):
     # Temperature criterion
     else:
 
-        print("TROPOPAUSE SET TO", atm_moist.trppT, "K")
+        print("TROPOPAUSE SET BY CONTANT VALUE OF", atm_moist.trppT, "K")
         trpp_idx = (np.abs(atm_moist.tmp - atm_moist.trppT)).argmin()
 
         atm_moist.trppidx   = trpp_idx                  # index
         atm_moist.trppP     = atm_moist.pl[trpp_idx]    # pressure 
         atm_moist.trppT     = atm_moist.tmpl[trpp_idx]  # temperature
-
-
-    
 
     return atm_moist

--- a/modules/radcoupler.py
+++ b/modules/radcoupler.py
@@ -6,6 +6,7 @@ Created on Mon Jan 23 13:05:00 2023
 @authors: 
 Tim Lichtenberg (TL)    
 Ryan Boukrouche (RB)
+Harrison Nicholls (HN)
 """
 
 import pickle as pkl
@@ -13,10 +14,40 @@ import pickle as pkl
 from modules.compute_moist_adiabat import compute_moist_adiabat
 from modules.dry_adiabat_timestep import compute_dry_adiabat
 
-def RadConvEqm(dirs, time, atm, loop_counter, COUPLER_options, standalone, cp_dry, trpp, calc_cf, rscatter, pure_steam_adj=False, surf_dt=False, cp_surf=1e5, mix_coeff_atmos=1e6, mix_coeff_surf=1e6):
+def RadConvEqm(dirs, time, atm, standalone, cp_dry, trppD, calc_cf, rscatter, pure_steam_adj=False, surf_dt=False, cp_surf=1e5, mix_coeff_atmos=1e6, mix_coeff_surf=1e6):
+    """Solves system for radiative-convective eqm
+
+    Parameters
+    ----------
+        dirs : dict
+            Named directories
+        time : dict
+            Dictionary of time values, including stellar age and evolution of planet
+        atm : atmos
+            Atmosphere object from atmosphere_column.py
+        standalone : bool
+            Running AEOLUS as standalone code?
+        cp_dry : bool
+            Compute dry adiabat case
+        trppD : bool 
+            Calculate tropopause dynamically?
+        calc_cf : bool
+            Calculate contribution function?
+        pure_steam_adj : bool
+            Use pure steam adjustment?
+        surf_dt : float
+            Timestep to use for T_surf timestepping cases
+        cp_surf : float
+            Surface heat capacity in T_surf timestepping cases
+        mix_coeff_atmos : float
+            Mixing coefficient (atmosphere) for T_surf timestepping cases?
+        mix_coeff_surf : float
+            Mixing coefficient (surface) for T_surf timestepping cases?
+            
+    """
 
     ### Moist/general adiabat
-    atm_moist = compute_moist_adiabat(atm, dirs, standalone, trpp, calc_cf, rscatter)
+    atm_moist = compute_moist_adiabat(atm, dirs, standalone, trppD, calc_cf, rscatter)
 
     ### Dry adiabat
     if cp_dry == True:
@@ -29,7 +60,8 @@ def RadConvEqm(dirs, time, atm, loop_counter, COUPLER_options, standalone, cp_dr
             print("Net, OLR => moist:", str(round(atm_moist.net_flux[0], 3)), str(round(atm_moist.LW_flux_up[0], 3)) + " W/m^2", end=" ")
             print("| dry:", str(round(atm_dry.net_flux[0], 3)), str(round(atm_dry.LW_flux_up[0], 3)) + " W/m^2", end=" ")
             print()
-    else: atm_dry = {}
+    else: 
+        atm_dry = {}
     
     # Plot
     if standalone == True:

--- a/modules/stellar_luminosity.py
+++ b/modules/stellar_luminosity.py
@@ -6,6 +6,7 @@ Created on Mon Jan 23 11:51:59 2023
 @authors: 
 Tim Lichtenberg (TL)    
 Ryan Boukrouche (RB)
+Harrison Nicholls (HN)
 """
 
 import pandas as pd
@@ -24,6 +25,9 @@ def natural_sort(l):
     return sorted(l, key = alphanum_key)
 
 def InterpolateStellarLuminosity(star_mass, time, mean_distance, albedo, Sfrac):
+
+    L_sun           = 3.828e+26        # W, IAU definition
+    AU              = 1.495978707e+11  # m
 
     if star_mass >= 0.1 and star_mass <= 1.4:
             
@@ -87,20 +91,16 @@ def InterpolateStellarLuminosity(star_mass, time, mean_distance, albedo, Sfrac):
             print("z_lum = ", z_lum)
             #print("interpolated_luminosity =", interpolated_luminosity)
         
-        # Stellar constant, W m-2
-        S_0    = interpolated_luminosity * 3.828e+26 / ( 4. * np.pi * (mean_distance*1.495978707e+11)**2. )
-        
-        # Mean flux averaged over surface area, W m-2
-        toa_heating             = ( 1. - albedo ) * S_0 / 4.
+        # Stellar luminosity, W m-2
+        L_star  = interpolated_luminosity * L_sun
 
     else: # Works only for TRAPPIST-1 right now!
+        L_star          = 0.000553*L_sun     # Trappist-1 luminosity
 
-        L_sun           = 3.828e+26        # W, IAU definition
-        AU              = 1.495978707e+11  # m
-        L_star          = 0.000553*L_sun                                            # Trappist-1 luminosity
-        toa_heating     = ( 1. - 0. ) * (L_star/(4.*np.pi*(mean_distance*AU)**2.))      # Tidally-locked, zero albedo
 
-    # Scale instellation by fixed fraction
-    S_0    = S_0 * Sfrac
+    F               = L_star /  ( 4. * np.pi * (mean_distance*AU)**2. )     # Flux at orbital radius (W/m^2)
+    toa_heating     = ( 1. - albedo ) * F     # Heating at TOA (W/m^2)
+    S_0             = F * Sfrac # Scale instellation by fixed fraction
     
     return S_0, toa_heating
+

--- a/utils/GeneralAdiabat.py
+++ b/utils/GeneralAdiabat.py
@@ -229,27 +229,30 @@ def atm_z(atm, idx):
 ## Assuming the ideal gas law and a constant latent heat of vaporization. 
 ## Select the molecule of interest with the switch argument (a string).
 def p_sat(switch,T): 
-    
+
     # Define volatile
-    if switch == 'H2O':
-        e = phys.satvps_function(phys.water)
-    if switch == 'CH4':
-        e = phys.satvps_function(phys.methane)
-    if switch == 'CO2':
-        e = phys.satvps_function(phys.co2)
-    if switch == 'CO':
-        e = phys.satvps_function(phys.co)
-    if switch == 'N2':
-        e = phys.satvps_function(phys.n2)
-    if switch == 'O2':
-        e = phys.satvps_function(phys.o2)
-    if switch == 'H2':
-        e = phys.satvps_function(phys.h2)
-    if switch == 'He':
-        e = phys.satvps_function(phys.he)
-    if switch == 'NH3':
-        e = phys.satvps_function(phys.nh3)
-    
+    match switch:
+        case 'H2O':
+            e = phys.satvps_function(phys.water)
+        case 'CH4':
+            e = phys.satvps_function(phys.methane)
+        case 'CO2':
+            e = phys.satvps_function(phys.co2)
+        case 'CO':
+            e = phys.satvps_function(phys.co)
+        case 'N2':
+            e = phys.satvps_function(phys.n2)
+        case 'O2':
+            e = phys.satvps_function(phys.o2)
+        case 'H2':
+            e = phys.satvps_function(phys.h2)
+        case 'He':
+            e = phys.satvps_function(phys.he)
+        case 'NH3':
+            e = phys.satvps_function(phys.nh3)   
+        case _:
+            raise Exception("Invalid volatile '%s' in p_sat()" % switch)
+        
     # Return saturation vapor pressure
     return float(f'{e(T):.2f}')
 '''
@@ -376,68 +379,69 @@ def Tdew(switch, p):
 ## Select the molecule of interest with the switch argument (a string).
 def L_heat(switch, T):
 
-    if switch == 'H2O':
-        L_sublimation   = phys.H2O.L_sublimation
-        L_vaporization  = phys.H2O.L_vaporization
-        MolecularWeight = phys.H2O.MolecularWeight
-        T_triple        = phys.H2O.TriplePointT
-        T_crit          = phys.H2O.CriticalPointT
-    
-    if switch == 'CH4':
-        L_sublimation   = phys.CH4.L_sublimation
-        L_vaporization  = phys.CH4.L_vaporization
-        MolecularWeight = phys.CH4.MolecularWeight
-        T_triple        = phys.CH4.TriplePointT
-        T_crit          = phys.CH4.CriticalPointT
+    match switch:
+        case 'H2O':
+            L_sublimation   = phys.H2O.L_sublimation
+            L_vaporization  = phys.H2O.L_vaporization
+            MolecularWeight = phys.H2O.MolecularWeight
+            T_triple        = phys.H2O.TriplePointT
+            T_crit          = phys.H2O.CriticalPointT
         
-    if switch == 'CO2':
-        L_sublimation   = phys.CO2.L_sublimation
-        L_vaporization  = phys.CO2.L_vaporization
-        MolecularWeight = phys.CO2.MolecularWeight
-        T_triple        = phys.CO2.TriplePointT
-        T_crit          = phys.CO2.CriticalPointT
-        
-    if switch == 'CO':
-        L_sublimation   = phys.CO.L_sublimation
-        L_vaporization  = phys.CO.L_vaporization
-        MolecularWeight = phys.CO.MolecularWeight
-        T_triple        = phys.CO.TriplePointT
-        T_crit          = phys.CO.CriticalPointT
+        case 'CH4':
+            L_sublimation   = phys.CH4.L_sublimation
+            L_vaporization  = phys.CH4.L_vaporization
+            MolecularWeight = phys.CH4.MolecularWeight
+            T_triple        = phys.CH4.TriplePointT
+            T_crit          = phys.CH4.CriticalPointT
             
-    if switch == 'N2':
-        L_sublimation   = phys.N2.L_sublimation
-        L_vaporization  = phys.N2.L_vaporization
-        MolecularWeight = phys.N2.MolecularWeight
-        T_triple        = phys.N2.TriplePointT
-        T_crit          = phys.N2.CriticalPointT
+        case 'CO2':
+            L_sublimation   = phys.CO2.L_sublimation
+            L_vaporization  = phys.CO2.L_vaporization
+            MolecularWeight = phys.CO2.MolecularWeight
+            T_triple        = phys.CO2.TriplePointT
+            T_crit          = phys.CO2.CriticalPointT
+            
+        case 'CO':
+            L_sublimation   = phys.CO.L_sublimation
+            L_vaporization  = phys.CO.L_vaporization
+            MolecularWeight = phys.CO.MolecularWeight
+            T_triple        = phys.CO.TriplePointT
+            T_crit          = phys.CO.CriticalPointT
+                
+        case 'N2':
+            L_sublimation   = phys.N2.L_sublimation
+            L_vaporization  = phys.N2.L_vaporization
+            MolecularWeight = phys.N2.MolecularWeight
+            T_triple        = phys.N2.TriplePointT
+            T_crit          = phys.N2.CriticalPointT
+            
+        case 'O2':
+            L_sublimation   = phys.O2.L_sublimation
+            L_vaporization  = phys.O2.L_vaporization
+            MolecularWeight = phys.O2.MolecularWeight
+            T_triple        = phys.O2.TriplePointT
+            T_crit          = phys.O2.CriticalPointT
         
-    if switch == 'O2':
-        L_sublimation   = phys.O2.L_sublimation
-        L_vaporization  = phys.O2.L_vaporization
-        MolecularWeight = phys.O2.MolecularWeight
-        T_triple        = phys.O2.TriplePointT
-        T_crit          = phys.O2.CriticalPointT
-    
-    if switch == 'H2':
-        L_sublimation   = phys.H2.L_vaporization # No H2 sublimation
-        L_vaporization  = phys.H2.L_vaporization
-        MolecularWeight = phys.H2.MolecularWeight
-        T_triple        = phys.H2.TriplePointT
-        T_crit          = phys.H2.CriticalPointT
-        
-    if switch == 'He':
-        L_sublimation   = phys.He.L_vaporization  # No He sublimation
-        L_vaporization  = phys.He.L_vaporization
-        MolecularWeight = phys.He.MolecularWeight
-        T_triple        = phys.He.TriplePointT
-        T_crit          = phys.He.CriticalPointT
-        
-    if switch == 'NH3':
-        L_sublimation   = phys.NH3.L_sublimation
-        L_vaporization  = phys.NH3.L_vaporization
-        MolecularWeight = phys.NH3.MolecularWeight
-        T_triple        = phys.NH3.TriplePointT
-        T_crit          = phys.NH3.CriticalPointT
+        case 'H2':
+            L_sublimation   = phys.H2.L_vaporization # No H2 sublimation
+            L_vaporization  = phys.H2.L_vaporization
+            MolecularWeight = phys.H2.MolecularWeight
+            T_triple        = phys.H2.TriplePointT
+            T_crit          = phys.H2.CriticalPointT
+            
+        case 'He':
+            L_sublimation   = phys.He.L_vaporization  # No He sublimation
+            L_vaporization  = phys.He.L_vaporization
+            MolecularWeight = phys.He.MolecularWeight
+            T_triple        = phys.He.TriplePointT
+            T_crit          = phys.He.CriticalPointT
+            
+        case 'NH3':
+            L_sublimation   = phys.NH3.L_sublimation
+            L_vaporization  = phys.NH3.L_vaporization
+            MolecularWeight = phys.NH3.MolecularWeight
+            T_triple        = phys.NH3.TriplePointT
+            T_crit          = phys.NH3.CriticalPointT
 
     # Gas-solid transition
     if T <= T_triple:
@@ -1122,7 +1126,7 @@ def plot_adiabats(atm,filename='output/general_adiabat.pdf'):
     ax1.text(0.02, 0.015, 'A', color="k", rotation=0, ha="left", va="bottom", fontsize=fs_l+3, transform=ax1.transAxes)
     ax2.text(0.02, 0.015, 'B', color="k", rotation=0, ha="left", va="bottom", fontsize=fs_l+3, transform=ax2.transAxes)
     #fig.suptitle(r'$\alpha$=%.1f'%atm.alpha_cloud)
-    fig.suptitle(r'T_$\rm{surf}$=%.0f K'%atm.ts)
+    fig.suptitle('$T_{surf}$=%.1f K, $T_{bot}$=%.1f K'% (atm.ts,atm.tmp[-1]))
     #plt.show()
 
     plt.savefig(filename, bbox_inches='tight')

--- a/utils/GeneralAdiabat.py
+++ b/utils/GeneralAdiabat.py
@@ -16,7 +16,8 @@ import scipy.interpolate as spint
 import math
 import matplotlib.pyplot as plt
 import copy
-from matplotlib import cm
+import matplotlib as mpl
+import numpy as np
 
 from utils.cp_funcs import *
 from utils.ClimateUtilities import *
@@ -30,56 +31,32 @@ import utils.phys as phys
 # https://chrisalbon.com/python/data_visualization/seaborn_color_palettes/
 no_colors   = 7
 vol_colors = {
-    "H2O"            : cm.get_cmap('PuBu', no_colors)(range(no_colors)),
-    "CO2"            : cm.get_cmap("Reds", no_colors)(range(no_colors)),
-    "H2"             : cm.get_cmap("Greens", no_colors)(range(no_colors)),
-    "N2"             : cm.get_cmap("Purples", no_colors)(range(no_colors)),
-    "O2"             : cm.get_cmap("Wistia", no_colors+2)(range(no_colors+2)),
-    "CH4"            : cm.get_cmap("RdPu", no_colors)(range(no_colors)),
-    "CO"             : cm.get_cmap("pink_r", no_colors)(range(no_colors)),
-    "S"              : cm.get_cmap("YlOrBr", no_colors)(range(no_colors)),
-    "He"             : cm.get_cmap("Greys", no_colors)(range(no_colors)),
-    "NH3"            : cm.get_cmap("summer", no_colors)(range(no_colors)),
-    "mixtures"       : cm.get_cmap("Set3", 9)(range(no_colors)),
-    "H2O-CO2"        : cm.get_cmap("Set3", 9)(range(no_colors))[1],
-    "CO2-H2O"        : cm.get_cmap("Set3", 9)(range(no_colors))[1],
-    "H2O-H2"         : cm.get_cmap("Set3", 9)(range(no_colors))[2],
-    "H2-H2O"         : cm.get_cmap("Set3", 9)(range(no_colors))[2],
-    "H2-CO"          : cm.get_cmap("Set3", 9)(range(no_colors))[3],
-    "CO-H2"          : cm.get_cmap("Set3", 9)(range(no_colors))[3],
-    "H2-CO2"         : cm.get_cmap("Set3", 9)(range(no_colors))[4],
-    "CO2-H2"         : cm.get_cmap("Set3", 9)(range(no_colors))[4],
-    "H2-CH4"         : cm.get_cmap("Set3", 9)(range(no_colors))[5],
-    "CH4-H2"         : cm.get_cmap("Set3", 9)(range(no_colors))[5],
-    "H2-N2"          : cm.get_cmap("Set2", 9)(range(no_colors))[0],
-    "N2-H2"          : cm.get_cmap("Set2", 9)(range(no_colors))[0],
-    "CO2-N2"         : cm.get_cmap("Set2", 9)(range(no_colors))[1],
-    "N2-CO2"         : cm.get_cmap("Set2", 9)(range(no_colors))[1],
-    # "H2O"            : sns.color_palette("PuBu", no_colors),
-    # "CO2"            : sns.color_palette("Reds", no_colors),
-    # "H2"             : sns.color_palette("Greens", no_colors),
-    # "N2"             : sns.color_palette("Purples", no_colors), # sns.cubehelix_palette(7)
-    # "O2"             : sns.light_palette("darkturquoise", no_colors),
-    # "CH4"            : sns.color_palette("RdPu", no_colors),
-    # "CO"             : sns.light_palette("#731d1d", no_colors),
-    # "S"              : sns.light_palette("#EBB434", no_colors),
-    # "He"             : sns.color_palette("Greys", no_colors),
-    # "NH3"            : sns.light_palette("teal", no_colors),
-    # "mixtures"       : sns.color_palette("Set2", 11),
-    # "H2O-CO2"        : sns.color_palette("Set2", 11)[9],
-    # "CO2-H2O"        : sns.color_palette("Set2", 11)[9],
-    # "H2O-H2"         : sns.color_palette("Set2", 11)[3],
-    # "H2-H2O"         : sns.color_palette("Set2", 11)[3],
-    # "H2-CO"          : sns.color_palette("Set2", 11)[7],
-    # "CO-H2"          : sns.color_palette("Set2", 11)[7],
-    # "H2-CO2"         : sns.color_palette("Set2", 11)[8],
-    # "CO2-H2"         : sns.color_palette("Set2", 11)[8],
-    # "H2-CH4"         : sns.color_palette("Set2", 11)[2],
-    # "CH4-H2"         : sns.color_palette("Set2", 11)[2],
-    # "H2-N2"          : sns.color_palette("Set2", 11)[4],
-    # "N2-H2"          : sns.color_palette("Set2", 11)[4],
-    # "CO2-N2"         : sns.color_palette("Set2", 11)[5],
-    # "N2-CO2"         : sns.color_palette("Set2", 11)[5],
+    "H2O"            : [mpl.colormaps["PuBu"](i) for i in np.linspace(0,1.0,no_colors)],
+    "CO2"            : [mpl.colormaps["Reds"](i) for i in np.linspace(0,1.0,no_colors)],
+    "H2"             : [mpl.colormaps["Greens"](i) for i in np.linspace(0,1.0,no_colors)],
+    "N2"             : [mpl.colormaps["Purples"](i) for i in np.linspace(0,1.0,no_colors)],
+    "O2"             : [mpl.colormaps["Wistia"](i) for i in np.linspace(0,1.0,no_colors+2)],
+    "CH4"            : [mpl.colormaps["RdPu"](i) for i in np.linspace(0,1.0,no_colors)],
+    "CO"             : [mpl.colormaps["pink_r"](i) for i in np.linspace(0,1.0,no_colors)],
+    "S"              : [mpl.colormaps["YlOrBr"](i) for i in np.linspace(0,1.0,no_colors)],
+    "He"             : [mpl.colormaps["Greys"](i) for i in np.linspace(0,1.0,no_colors)],
+    "NH3"            : [mpl.colormaps["summer"](i) for i in np.linspace(0,1.0,no_colors)],
+    "mixtures"       : [mpl.colormaps["Set3"](i) for i in np.linspace(0,1.0,no_colors)],
+    "H2O-CO2"        : mpl.colormaps["Set3"](1.0/no_colors),
+    "CO2-H2O"        : mpl.colormaps["Set3"](1.0/no_colors),
+    "H2O-H2"         : mpl.colormaps["Set3"](2.0/no_colors),
+    "H2-H2O"         : mpl.colormaps["Set3"](2.0/no_colors),
+    "CO-H2"          : mpl.colormaps["Set3"](3.0/no_colors),
+    "H2-CO"          : mpl.colormaps["Set3"](3.0/no_colors),
+    "H2-CO2"         : mpl.colormaps["Set3"](4.0/no_colors),
+    "CO2-H2"         : mpl.colormaps["Set3"](4.0/no_colors),
+    "CH4-H2"         : mpl.colormaps["Set3"](5.0/no_colors),
+    "H2-CH4"         : mpl.colormaps["Set3"](5.0/no_colors),
+    "H2-CH4"         : mpl.colormaps["Set3"](5.0/no_colors),
+    "H2-N2"          : mpl.colormaps["Set2"](0.0/no_colors),
+    "N2-H2"          : mpl.colormaps["Set2"](0.0/no_colors),
+    "CO2-N2"         : mpl.colormaps["Set2"](1.0/no_colors),
+    "N2-CO2"         : mpl.colormaps["Set2"](1.0/no_colors),
     "black_1"        : "#000000",
     "black_2"        : "#323232",
     "black_3"        : "#7f7f7f",
@@ -1134,3 +1111,53 @@ def plot_adiabats(atm,filename='output/general_adiabat.pdf'):
 
     return
 
+
+####################################
+##### Stand-alone initial conditions
+####################################
+if __name__ == "__main__":
+
+    # Surface temperature & partial pressures
+    T_surf                  = 400                           # K
+    pH2O                    = p_sat('H2O',T_surf)           # Pa
+    pCO2                    = 0.                            # Pa
+    pH2                     = 0.                            # Pa
+    pN2                     = 3e+5                          # Pa
+    pCH4                    = 0.                            # Pa
+    pO2                     = 0.                            # Pa
+    pHe                     = 0.                            # Pa
+    pNH3                    = 0.                            # Pa
+    P_surf                  = pH2O + pCO2 + pH2 + pN2 + pCH4 + pO2 + pHe + pNH3  # Pa
+
+    # Set fraction of condensate retained in column (0 = full rainout)
+    alpha_cloud             = 0.0
+
+    pl_radius     = 6.371e6             # m, planet radius
+    pl_mass       = 5.972e24            # kg, planet mass
+    P_top         = 1.0                 # Pa
+    
+    # Volatile molar concentrations in the dictionary below are defined as fractions that must sum to one
+    # The vanilla setting defines a water-saturated atmosphere with a 3 bar N2 background
+    vol_list = { 
+                  "H2O" : pH2O / P_surf,   
+                  "CO2" : pCO2 / P_surf,
+                  "H2"  : pH2  / P_surf,
+                  "N2"  : pN2  / P_surf,
+                  "CH4" : pCH4 / P_surf,
+                  "O2"  : pO2  / P_surf,
+                  "CO"  : pN2  / P_surf,
+                  "He"  : pHe  / P_surf,
+                  "NH3" : pNH3 / P_surf,
+                }
+    # Create atmosphere object
+    atm                     = atmos(T_surf, P_surf, P_top, pl_radius, pl_mass, vol_mixing=vol_list)
+
+    # Set fraction of condensate retained in column (0 = full rainout)
+    atm.alpha_cloud         = alpha_cloud
+    
+    # Calculate moist adiabat + condensation
+    atm                     = general_adiabat(atm)
+
+    # Plot adiabat
+    plot_adiabats(atm, filename="../output/general_adiabat.pdf")
+    

--- a/utils/SocRadModel.py
+++ b/utils/SocRadModel.py
@@ -20,10 +20,23 @@ import utils.RayleighSpectrum as RayleighSpectrum
 from utils.atmosphere_column import atmos
 
 def radCompSoc(atm, dirs, recalc, calc_cf=False, rscatter=False):
+    """Runs SOCRATES to calculate fluxes and heating rates
 
-    # Enable or disable calculating contribution function
-    # ENABLE RIGHT ENVIRONMENT IN TERMINAL FIRST
-    # calc_cf = False
+    Parameters
+    ----------
+        atm : atmos
+            Atmosphere object from atmosphere_column.py
+        dirs : dict
+            Named directories
+        recalc : bool
+            Is this function call a 'recalculation' case accounting for a tropopause?
+        calc_cf : bool
+            Calculate contribution function?
+        rscatter : bool
+            Include Rayleigh scattering?
+            
+    """
+
     molar_mass      = {
               "H2O" : 0.01801528,           # kg mol−1
               "CO2" : 0.04401,              # kg mol−1

--- a/utils/SocRadModel.py
+++ b/utils/SocRadModel.py
@@ -110,52 +110,29 @@ def radCompSoc(atm, dirs, recalc, calc_cf=False, rscatter=False):
     latitude        = 0
     basis_function  = 1
 
+    basename = 'profile'
+
     # Write values to netcdf: SOCRATES Userguide p. 45
     blockPrint()
-    nctools.ncout_surf('profile.surf', longitude, latitude, basis_function, surface_albedo)
-    nctools.ncout2d('profile.tstar', 0, 0, atm.ts, 'tstar', longname="Surface Temperature", units='K')
-    nctools.ncout2d('profile.pstar', 0, 0, atm.ps, 'pstar', longname="Surface Pressure", units='PA')
-    nctools.ncout2d('profile.szen', 0, 0, zenith_angle, 'szen', longname="Solar zenith angle", units='Degrees')
-    nctools.ncout2d('profile.stoa', 0, 0, atm.toa_heating, 'stoa', longname="Solar Irradiance at TOA", units='WM-2')
+    nctools.ncout_surf(basename+'.surf', longitude, latitude, basis_function, surface_albedo)
+    nctools.ncout2d(   basename+'.tstar', 0, 0, atm.ts, 'tstar', longname="Surface Temperature", units='K')
+    nctools.ncout2d(   basename+'.pstar', 0, 0, atm.ps, 'pstar', longname="Surface Pressure", units='PA')
+    nctools.ncout2d(   basename+'.szen', 0, 0, zenith_angle, 'szen', longname="Solar zenith angle", units='Degrees')
+    nctools.ncout2d(   basename+'.stoa', 0, 0, atm.toa_heating, 'stoa', longname="Solar Irradiance at TOA", units='WM-2')
     # T, P + volatiles
-    nctools.ncout3d('profile.t', 0, 0,   atm.p,  atm.tmp, 't', longname="Temperature", units='K')
-    nctools.ncout3d('profile.tl', 0, 0,  atm.pl, atm.tmpl, 'tl', longname="Temperature", units='K')
-    nctools.ncout3d('profile.p', 0, 0,   atm.p,  atm.p, 'p', longname="Pressure", units='PA')
-    nctools.ncout3d('profile.q', 0, 0,   atm.p,  molar_mass['H2O'] / atm.mu * atm.x_gas["H2O"], 'q', longname="q", units='kg/kg') 
-    if "CO2" in atm.vol_list.keys():
-        nctools.ncout3d('profile.co2', 0, 0, atm.p,  molar_mass['CO2'] / atm.mu * atm.x_gas["CO2"], 'co2', longname="CO2", units='kg/kg') 
-    if "O3" in atm.vol_list.keys():
-        nctools.ncout3d('profile.o3', 0, 0,  atm.p,  molar_mass['O3'] / atm.mu * atm.x_gas["O3"], 'o3', longname="O3", units='kg/kg') 
-    if "N2O" in atm.vol_list.keys():
-        nctools.ncout3d('profile.n2o', 0, 0,  atm.p,  molar_mass['N2O'] / atm.mu * atm.x_gas["N2O"], 'n2o', longname="N2O", units='kg/kg') 
-    if "CO" in atm.vol_list.keys():
-        nctools.ncout3d('profile.co', 0, 0,  atm.p,  molar_mass['CO'] / atm.mu * atm.x_gas["CO"], 'co', longname="CO", units='kg/kg') 
-    if "CH4" in atm.vol_list.keys():
-        nctools.ncout3d('profile.ch4', 0, 0, atm.p,  molar_mass['CH4'] / atm.mu * atm.x_gas["CH4"], 'ch4', longname="CH4", units='kg/kg') 
-    if "O2" in atm.vol_list.keys():
-        nctools.ncout3d('profile.o2', 0, 0,  atm.p,  molar_mass['O2'] / atm.mu * atm.x_gas["O2"], 'o2', longname="O2", units='kg/kg')
-    if "NO" in atm.vol_list.keys():
-        nctools.ncout3d('profile.no', 0, 0,  atm.p,  molar_mass['NO'] / atm.mu * atm.x_gas["NO"], 'no', longname="NO", units='kg/kg') 
-    if "SO2" in atm.vol_list.keys():
-        nctools.ncout3d('profile.so2', 0, 0,  atm.p,  molar_mass['SO2'] / atm.mu * atm.x_gas["SO2"], 'so2', longname="SO2", units='kg/kg') 
-    if "NO2" in atm.vol_list.keys():
-        nctools.ncout3d('profile.no2', 0, 0,  atm.p,  molar_mass['NO2'] / atm.mu * atm.x_gas["NO2"], 'no2', longname="NO2", units='kg/kg') 
-    if "NH3" in atm.vol_list.keys():
-        nctools.ncout3d('profile.nh3', 0, 0,  atm.p,  molar_mass['NH3'] / atm.mu * atm.x_gas["NH3"], 'nh3', longname="NH3", units='kg/kg') 
-    if "HNO3" in atm.vol_list.keys():
-        nctools.ncout3d('profile.hno3', 0, 0,  atm.p,  molar_mass['HNO3'] / atm.mu * atm.x_gas["HNO3"], 'hno3', longname="HNO3", units='kg/kg')
-    if "N2" in atm.vol_list.keys():
-        nctools.ncout3d('profile.n2', 0, 0,  atm.p,  molar_mass['N2'] / atm.mu * atm.x_gas["N2"], 'n2', longname="N2", units='kg/kg') 
-    if "H2" in atm.vol_list.keys():
-        nctools.ncout3d('profile.h2', 0, 0,  atm.p,  molar_mass['H2'] / atm.mu * atm.x_gas["H2"], 'h2', longname="H2", units='kg/kg')
-    if "He" in atm.vol_list.keys():
-        nctools.ncout3d('profile.he', 0, 0,  atm.p,  molar_mass['He'] / atm.mu * atm.x_gas["He"], 'he', longname="He", units='kg/kg')
-    if "OCS" in atm.vol_list.keys():
-        nctools.ncout3d('profile.ocs', 0, 0,  atm.p,  molar_mass['OCS'] / atm.mu * atm.x_gas["OCS"], 'ocs', longname="OCS", units='kg/kg')
-    
-    enablePrint()
+    nctools.ncout3d(basename+'.t', 0, 0,   atm.p,  atm.tmp, 't', longname="Temperature", units='K')
+    nctools.ncout3d(basename+'.tl', 0, 0,  atm.pl, atm.tmpl, 'tl', longname="Temperature", units='K')
+    nctools.ncout3d(basename+'.p', 0, 0,   atm.p,  atm.p, 'p', longname="Pressure", units='PA')
+    nctools.ncout3d(basename+'.q', 0, 0,   atm.p,  molar_mass['H2O'] / atm.mu * atm.x_gas["H2O"], 'q', longname="q", units='kg/kg') 
 
-    basename = 'profile'
+    allowed_vols = {"CO2", "O3", "N2O", "CO", "CH4", "O2", "NO", "SO2", "NO2", "NH3", "HNO3", "N2", "H2", "He", "OCS"}
+    for vol in atm.vol_list.keys():
+        if vol in allowed_vols:
+            vol_lower = str(vol).lower()
+            nctools.ncout3d(basename+'.'+vol_lower, 0, 0, atm.p,  molar_mass[vol] / atm.mu * atm.x_gas[vol], vol_lower, longname=vol, units='kg/kg') 
+
+    enablePrint()
+   
     s = " "
 
     if rscatter == True:
@@ -163,28 +140,29 @@ def radCompSoc(atm, dirs, recalc, calc_cf=False, rscatter=False):
     else:
         scatter_flag = ""
 
-    # Anchor spectral files and run SOCRATES
-    seq4 = ("Cl_run_cdf -B", basename,"-s", spectral_file, "-R 1", str(atm.nbands), " -ch ", str(atm.nbands), " -S -g 2 -C 5 -u", scatter_flag)
+    # Call sequences for: anchor spectral files and run SOCRATES
+    seq4 = ("Cl_run_cdf","-B", basename,"-s", spectral_file, "-R 1", str(atm.nbands), " -ch ", str(atm.nbands), " -S -g 2 -C 5 -u", scatter_flag)
     seq5 = ("fmove", basename,"currentsw")
-    seq6 = ("Cl_run_cdf -B", basename,"-s", spectral_file, "-R 1 ", str(atm.nbands), " -ch ", str(atm.nbands), " -I -g 2 -C 5 -u", scatter_flag)
+    
+    seq6 = ("Cl_run_cdf","-B", basename,"-s", spectral_file, "-R 1 ", str(atm.nbands), " -ch ", str(atm.nbands), " -I -g 2 -C 5 -u", scatter_flag)
     seq7 = ("fmove", basename,"currentlw")
 
     if calc_cf == True:
         seq8 = ("Cl_run_cdf -B", basename,"-s", spectral_file, "-R 1 ", str(atm.nbands), " -ch ", str(atm.nbands), " -I -g 2 -C 5 -u -ch 1", scatter_flag)
         seq9 = ("fmove", basename, "currentlw_cff")
 
-    comline1 = s.join(seq4)
-    comline2 = s.join(seq5)
-    comline3 = s.join(seq6)
-    comline4 = s.join(seq7)
     if calc_cf == True:
         comline5 = s.join(seq8)
         comline6 = s.join(seq9)
 
-    os.system(comline1)
-    os.system(comline2)
-    os.system(comline3)
-    os.system(comline4)
+    # SW calculation with SOCRATES
+    subprocess.run(list(seq4),check=True,stderr=subprocess.DEVNULL)
+    subprocess.run(list(seq5),check=True,stderr=subprocess.DEVNULL)
+
+    # LW calculation with SOCRATES
+    subprocess.run(list(seq6),check=True,stderr=subprocess.DEVNULL)
+    subprocess.run(list(seq7),check=True,stderr=subprocess.DEVNULL)
+
     if calc_cf == True:
         os.system(comline5)
         os.system(comline6)

--- a/utils/atmosphere_column.py
+++ b/utils/atmosphere_column.py
@@ -2,55 +2,103 @@
 # class for atmospheric column data
 
 import numpy as np
-
-R_universal = 8.31446261815324 # Universal gas constant, J.K-1.mol-1
+from utils import phys
 
 class atmos:
-    '''
-    Atmosphere class
-    '''
-    def __init__(self, T_surf, P_surf, vol_list, calc_cf=False, trppT=0):
+    """Atmosphere class    
+    
+    Stores compositional and thermodynamic information for the column.    
+    Also stores planetary parameters.   
+
+    """
+    
+    def __init__(self, T_surf: float, P_surf: float, P_top: float, pl_radius: float, pl_mass: float, 
+                 vol_mixing: dict = {}, vol_partial: dict = {}, 
+                 calc_cf: bool=False, 
+                 trppT: float = 290):
+        
+        """Inits atmos class.
+
+        One of either vol_mixing or vol_partial must be passed in. 
+        If vol_partial is passed, then the value of P_surf is recalculated as the sum of partial pressures.
+
+        Parameters
+        ----------
+            T_surf : float
+                Surface temperature [K]
+            P_surf : float
+                Surface pressure [Pa]
+            P_top : float
+                Pressure at top of column [Pa]
+            pl_radius : float
+                Radius of rocky part of planet [m]
+            pl_mass : float
+                Mass of rocky part of planet [kg]
+
+            vol_mixing : dict
+                Dictionary of volatiles (keys) and mixing ratios (values)
+            vol_partial: dict
+                Dictionary of volatiles (keys) and partial pressures (values)
+
+            calc_cf : bool
+                Calculate contribution function?
+
+            trppT : float
+                Tropopause temperature
+                
+        """
+
+        # Parse volatiles 
+        if (len(vol_mixing) == 0) and (len(vol_partial) == 0):
+            raise Exception("Either vol_mixing OR vol_partial must be passed to atmos.__init__ function!\nNeither were.")
+        if (len(vol_mixing) > 0) and (len(vol_partial) > 0):
+            raise Exception("Either vol_mixing OR vol_partial must be passed to atmos.__init__ function!\nBoth were.")
+        
+        if len(vol_mixing) > 0:  # Set by mixing ratio
+            self.ps = P_surf
+            if (P_surf <= 0.0):
+                raise Exception("Surface pressure passed to atmos.__init__ must be positive!\nValue passed = '%g'" % P_surf)
+            
+            tot_mixing =  float(sum(vol_mixing.values()))  # Ensure mixing ratios add up to unity
+            self.vol_list = {}
+            for key in vol_mixing.keys():
+                self.vol_list[key] = vol_mixing[key]/tot_mixing
+
+        
+        if len(vol_partial) > 0: # Set by partial pressure
+            self.ps = float(sum(vol_partial.values()))
+            self.vol_list = {}
+            for key in vol_partial.keys():
+                self.vol_list[key] = vol_partial[key]/self.ps
+
+        # Initialise other variables
         self.alpha_cloud 	= 0.0 	    	# The fraction of condensate retained in the column; 1 -> Li et al 2018; 0 -> full rainout
-
-        # If vol_list is given in partial pressures, calculate mixing ratios
-        if (type(P_surf) == str) or (type(P_surf) == float and P_surf <= 0.):
-            P_surf          = sum(vol_list.values())
-            print("Calculate mixing ratios from partial pressures.")
-            print("P_surf:", P_surf)
-            print("p_i:", vol_list)
-            for vol in vol_list.keys():
-                vol_list[vol] = vol_list[vol]/P_surf
-            print("x_i:", vol_list)
-
-        self.ps 			= P_surf 	 	# Surface pressure, Pa
+        
         self.ts 			= T_surf		# Surface temperature, K
-        self.vol_list 		= vol_list		# Names + mixing ratios dict
 
-        self.ptop 			= 10 			# Top pressure in Pa
+        self.ptop 			= P_top 			# Top pressure in Pa
         self.nlev 			= 10000  	   	# Number of vertical levels for adiabat integration
         self.step    		= 0.01  		# Adjust to match self.nlev
         self.nlev_save		= 100   		# Number of levels to save object
         self.p 				= np.zeros(self.nlev) 	   		# np.ones(self.nlev)
         self.pl 			= np.zeros(self.nlev+1)    		# np.ones(self.nlev+1)
 
+        self.trppT          = trppT                 # Fixed value [K]
         self.trppidx		= 0 				 	# Tropopause: idx
         self.trppP 			= 0 				 	# Tropopause: prs
 
-        # Nominal tropopause T in K; if set to zero dynamically calculated in SocRadConv.py
-        self.trppT 			= 290 				 	# Tropopause: tmp
-        
         self.dt 			= 0.5 							# days
 
         self.toa_heating    = 0. 							# W/m^2
-        self.star_lum       = 0. 							# L_sun
+        self.star_lum       = 0.0							# L_sun
 
         self.albedo_s   	= 0.0 							# surface albedo
         self.albedo_pl   	= 0.175 						# Bond albedo (scattering)
         self.zenith_angle  	= 54.55							# solar zenith angle, Hamano+15 (arccos(1/sqrt(3) = 54.74), Wordsworth+ 10: 48.19 (arccos(2/3)), see Cronin 14 (mu = 0.58 -> theta = arccos(0.58) = 54.55) for definitions
 
-        self.planet_mass 	= 5.972e+24 					# kg
-        self.planet_radius 	= 6.3781e+6 					# m
-        self.grav_s 		= 6.67408e-11*self.planet_mass/(self.planet_radius**2) # m s-2
+        self.planet_mass    = pl_mass
+        self.planet_radius  = pl_radius
+        self.grav_s 		= phys.G*self.planet_mass/(self.planet_radius**2) # m s-2
         
         self.tmp 			= np.zeros(self.nlev)      		# self.ts*np.ones(self.nlev)
         self.tmpl 			= np.zeros(self.nlev+1)
@@ -81,8 +129,8 @@ class atmos:
         self.cp      		= np.zeros(self.nlev) # Mean heat capacity
 
         # Define T and P arrays from surface up
-        self.tmp[0]         = T_surf         		# K
-        self.p[0]           = P_surf         		# Pa
+        self.tmp[0]         = self.ts         		# K
+        self.p[0]           = self.ps         		# Pa
         self.z[0]           = 0         			# m
         self.grav_z[0]      = self.grav_s 			# m s-2
 
@@ -101,7 +149,7 @@ class atmos:
             #self.x_ocean[vol]    = 0.
 
             # Surface partial pressures
-            self.p_vol[vol][0]   = self.ps * vol_list[vol]
+            self.p_vol[vol][0]   = self.ps * self.vol_list[vol]
 
         # Radiation heating and fluxes
         self.LW_flux_up 			= np.zeros(self.nlev)				# W/m^2
@@ -125,5 +173,41 @@ class atmos:
             self.cff_i					= np.zeros([self.nbands,self.nlev]) # cf per band
             self.LW_flux_up_i 			= np.zeros([self.nbands,self.nlev])
 
+    def write_PT(self,filename: str="output/PT.tsv", punit:str = "Pa"):
+        """Write PT profile to file, with descending pressure.
 
-        
+        Useful for when run outside of PROTEUS and for debugging.
+        Designed with VULCAN compatibility in mind.
+
+        Parameters
+        ----------
+            filename : string
+                Output filename
+            punit : string
+                Pressure unit to save with
+
+        """
+
+        p_scalefactor = 1.0
+        match punit:
+            case "Pa":
+                p_scalefactor = 1.0
+            case "bar":
+                p_scalefactor = 1.0e-5
+            case "dyne/cm2":
+                p_scalefactor = 1.0e5
+            case "atm":
+                p_scalefactor = 1.01325e5
+            case _:
+                raise Exception("Unrecognised pressure unit '%s'"%punit)
+
+        p_save = np.array(self.pl) * p_scalefactor
+        T_save = np.array(self.tmpl)
+
+        X = np.array([p_save,T_save]).T[::-1]
+
+        header = '# (%s)\t(K)\nPressure\tTemp' % punit
+
+        np.savetxt(filename,X,fmt='%1.5e',header=header,comments='',delimiter='\t')
+
+

--- a/utils/atmosphere_column.py
+++ b/utils/atmosphere_column.py
@@ -5,19 +5,16 @@ import numpy as np
 from utils import phys
 
 class atmos:
-    """Atmosphere class    
-    
-    Stores compositional and thermodynamic information for the column.    
-    Also stores planetary parameters.   
-
-    """
     
     def __init__(self, T_surf: float, P_surf: float, P_top: float, pl_radius: float, pl_mass: float, 
                  vol_mixing: dict = {}, vol_partial: dict = {}, 
                  calc_cf: bool=False, 
                  trppT: float = 290):
         
-        """Inits atmos class.
+        """Atmosphere class    
+    
+        Stores compositional and thermodynamic information for the column.    
+        Also stores planetary parameters.   
 
         One of either vol_mixing or vol_partial must be passed in. 
         If vol_partial is passed, then the value of P_surf is recalculated as the sum of partial pressures.

--- a/utils/atmosphere_column.py
+++ b/utils/atmosphere_column.py
@@ -184,7 +184,7 @@ class atmos:
             filename : string
                 Output filename
             punit : string
-                Pressure unit to save with
+                Pressure unit to use. Options: Pa, bar, dyne/cm2, atm.
 
         """
 
@@ -201,8 +201,8 @@ class atmos:
             case _:
                 raise Exception("Unrecognised pressure unit '%s'"%punit)
 
-        p_save = np.array(self.pl) * p_scalefactor
-        T_save = np.array(self.tmpl)
+        p_save = np.array(self.p) * p_scalefactor
+        T_save = np.array(self.tmp)
 
         X = np.array([p_save,T_save]).T[::-1]
 


### PR DESCRIPTION
The main goal of this update was to make using the atmos object smoother. These changes are:
- Planetary radius and mass are passed in to `__init__`. This will be important for PROTEUS and is useful for AEOLUS anyway. Resolves #24.
- `vol_list` is now explicitly either partial pressures or mixing ratios, rather than ambiguously one or the other. The object accepts either `vol_mixing` or `vol_partial`, which are then appropriately normalised and converted to `vol_list`.
- Tropopause parameterisation is now clearer to use, no longer depending on trpp=0 to calculate it dynamically.
- It's now possible to write the PT profile to a plain text file, which is helpful for debugging and for use with VULCAN.
- Enabled (and tested) surface time-stepping, which can toggled on or off.
- These changes include significant documentation to explain the update call sequences, input parsing, and variable names.

Bug fixes:
- Previously the code would crash if you input a stellar mass below the evolution track boundaries. This is now fixed, although it's still set to only use the value for TRAPPIST-1.

Quality of life updates:
- Removed annoying SOCRATES warning relating to integer comparison. SOCRATES is now called using `subprocess.run()` rather than via `os.system()`.
- Updated general adiabat plotting to be compatible with upcoming Matplotlib updates (previous code threw deprecation warnings).
- Performance updates which make use of the `match` keyword (added in Python 3.10).
- Documentation.

**PROTEUS will need updating to reflect changes to the atmosphere object.**

Resolves #14, or at least I was unable to replicate this bug in any of my tests.
