### PR TITLE
Fixed bug in SW flux calculation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -35,7 +35,7 @@
                 * Update to the latest stable version: `brew upgrade python`
                 * Install `tkinter`: `brew install python-tk@3.11`
                 * Refresh your shell / `source ~/.zsrhrc` (ARM) / `source ~/.bash_profile` (Intel)
-                * Install all necessary packages: `pip3 install matplotlib pandas netcdf4 matplotlib numpy pandas scipy sympy natsort`
+                * Install all necessary packages: `pip3 install matplotlib pandas netcdf4 matplotlib numpy pandas scipy sympy`
             * Make the new Python version the system default (check what `brew` tells you during/after the `brew install python` step):
                 * ARM: `export PATH="/opt/homebrew/opt/python/libexec/bin:$PATH"`
                 * Intel: `export PATH="/usr/local/opt/python/libexec/bin:$PATH"`

--- a/SocRadConv.py
+++ b/SocRadConv.py
@@ -18,6 +18,7 @@ import numpy as np
 
 from modules.stellar_luminosity import InterpolateStellarLuminosity
 from modules.radcoupler import RadConvEqm
+from modules.plot_flux_balance import plot_flux_balance
 
 import utils.GeneralAdiabat as ga # Moist adiabat with multiple condensibles
 import utils.SocRadModel as SocRadModel
@@ -47,11 +48,11 @@ if __name__ == "__main__":
     pl_mass       = 5.972e24            # kg, planet mass
 
     # Boundary conditions for pressure & temperature
-    T_surf        = 300.0                # K
-    P_top         = 10.0                  # Pa
+    T_surf        = 298.0                # K
+    P_top         = 1.0                  # Pa
 
     # Define volatiles by mole fractions
-    # P_surf       = 50 * 1e5
+    # P_surf       = 100 * 1e5
     # vol_mixing = { 
     #                 "CO2"  : 1.0 - 5e-2,
     #                 "H2O"  : 5e-2 - 1e-6,
@@ -77,16 +78,16 @@ if __name__ == "__main__":
     # Define volatiles by partial pressures
     P_surf = 0.0
     vol_mixing = {}
-    vol_partial    = { 
-                          "H2O" :  0.004e5,
-                          "NH3" :  0.,
-                          "CO2" :  0.035e5,
-                          "CH4" :  0.,
-                          "CO"  :  0.,
-                          "O2"  :  0.20e5,
-                          "N2"  :  0.78e5,
-                          "H2"  :  0.
-                        }
+    vol_partial = {
+        "H2O" : 0.003583e5,
+        "NH3" : 0.,
+        "CO2" : 0.035e5,
+        "CH4" : 0.,
+        "CO" : 0.,
+        "O2" : 0.20e5,
+        "N2" : 0.78e5,
+        "H2" : 0.
+        }
 
     # Stellar heating on/off
     stellar_heating = True
@@ -95,7 +96,7 @@ if __name__ == "__main__":
     custom_ISR = False
 
     # Rayleigh scattering on/off
-    rscatter = True
+    rscatter = False
 
     # Compute contribution function
     calc_cf = False
@@ -105,7 +106,7 @@ if __name__ == "__main__":
 
     # Tropopause calculation
     trppD = False   # Calculate dynamically?
-    trppT = 70.0     # Fixed tropopause value if not calculated dynamically
+    trppT = 30.0     # Fixed tropopause value if not calculated dynamically
     
     # Surface temperature time-stepping
     surf_dt = False
@@ -131,6 +132,7 @@ if __name__ == "__main__":
         atm.toa_heating = 0.
     else:
         print("TOA heating:", round(atm.toa_heating), "W/m^2")
+
         
     # Compute heat flux
     dirs = {"output": os.getcwd()+"/output", "rad_conv": os.getcwd()}
@@ -140,10 +142,14 @@ if __name__ == "__main__":
     if (cp_dry):
         ga.plot_adiabats(atm_dry,filename="output/dry_ga.pdf")
         atm_dry.write_PT(filename="output/dry_pt.tsv")
+        ga.plot_fluxes(atm_dry,filename="output/dry_fluxes.pdf")
+
 
     ga.plot_adiabats(atm_moist,filename="output/moist_ga.pdf")
     atm_moist.write_PT(filename="output/moist_pt.tsv")
+    ga.plot_fluxes(atm_moist,filename="output/moist_fluxes.pdf")
 
+    plot_flux_balance(atm_dry,atm_moist,cp_dry,time,dirs)
 
     end = t.time()
     print("Runtime:", round(end - start,2), "s")

--- a/modules/compute_moist_adiabat.py
+++ b/modules/compute_moist_adiabat.py
@@ -37,8 +37,11 @@ def compute_moist_adiabat(atm, dirs, standalone, trppD, calc_cf=False, rscatter=
 
     atm_moist = copy.deepcopy(atm)
 
+
     # Build general adiabat structure
     atm_moist = ga.general_adiabat(atm_moist)
+
+
 
     # Run SOCRATES
     atm_moist = SocRadModel.radCompSoc(atm_moist, dirs, recalc=False, calc_cf=calc_cf, rscatter=rscatter)

--- a/modules/plot_flux_balance.py
+++ b/modules/plot_flux_balance.py
@@ -14,11 +14,8 @@ import math
 #import json
 
 from modules.spectral_planck_surface import surf_Planck_nu
+import utils.GeneralAdiabat as ga # Moist adiabat with multiple condensibles
 
-try:
-    import GeneralAdiabat as ga # Moist adiabat with multiple condensibles
-except:
-    import atm_rad_conv.GeneralAdiabat as ga
 
 def plot_flux_balance(atm_dry, atm_moist, cp_dry, time, dirs):
 

--- a/modules/radcoupler.py
+++ b/modules/radcoupler.py
@@ -47,6 +47,7 @@ def RadConvEqm(dirs, time, atm, standalone, cp_dry, trppD, calc_cf, rscatter, pu
     """
 
     ### Moist/general adiabat
+
     atm_moist = compute_moist_adiabat(atm, dirs, standalone, trppD, calc_cf, rscatter)
 
     ### Dry adiabat

--- a/utils/GeneralAdiabat.py
+++ b/utils/GeneralAdiabat.py
@@ -882,6 +882,7 @@ def general_adiabat( atm ):
     dry_list = []
     Tsurf = atm.ts
     alpha = atm.alpha_cloud
+    toa_heating = atm.toa_heating
     for vol in atm.vol_list.keys():
         if atm.vol_list[vol] * atm.ps > p_sat(vol, atm.ts):
             new_psurf += p_sat(vol,atm.ts)
@@ -895,6 +896,7 @@ def general_adiabat( atm ):
             atm.vol_list[vol] = new_p_vol[vol] / new_psurf
         atm = atmos(Tsurf, new_psurf, atm.ptop, atm.planet_radius, atm.planet_mass, vol_mixing=atm.vol_list, trppT=atm.trppT)
         atm.alpha_cloud = alpha
+        atm.toa_heating = toa_heating
     for vol in atm.vol_list.keys():
         if atm.vol_list[vol] * atm.ps == p_sat(vol,atm.ts):
             wet_list.append(vol)
@@ -1014,6 +1016,33 @@ def interpolate_atm(atm):
     return atm
 
 # Plotting
+def plot_fluxes(atm,filename='output/fluxes.pdf'):
+
+    fig,ax = plt.subplots()
+
+    ax.axvline(0,color='black',lw=0.8)
+
+    ax.plot(atm.flux_up_total,atm.pl,color='red',label='UP',lw=1)
+    ax.plot(atm.SW_flux_up   ,atm.pl,color='red',label='UP SW',linestyle='dotted',lw=2)
+    ax.plot(atm.LW_flux_up   ,atm.pl,color='red',label='UP LW',linestyle='dashed',lw=1)
+
+    ax.plot(-1.0*atm.flux_down_total,atm.pl,color='green',label='DN',lw=2)
+    ax.plot(-1.0*atm.SW_flux_down   ,atm.pl,color='green',label='DN SW',linestyle='dotted',lw=3)
+    ax.plot(-1.0*atm.LW_flux_down   ,atm.pl,color='green',label='DN LW',linestyle='dashed',lw=2)
+
+    ax.plot(atm.net_flux ,atm.pl,color='black',label='NET')
+
+    ax.set_xlabel("Upward-directed flux [W m-2]")
+    ax.set_ylabel("Pressure [Pa]")
+    ax.set_yscale("log")
+    ax.set_ylim([atm.pl[-1],atm.pl[0]])
+
+    ax.legend(loc='upper left')
+
+    fig.savefig(filename)
+
+
+
 def plot_adiabats(atm,filename='output/general_adiabat.pdf'):
 
     # sns.set_style("ticks")

--- a/utils/SocRadModel.py
+++ b/utils/SocRadModel.py
@@ -113,17 +113,20 @@ def radCompSoc(atm, dirs, recalc, calc_cf=False, rscatter=False):
     basename = 'profile'
 
     # Write values to netcdf: SOCRATES Userguide p. 45
-    blockPrint()
+    # blockPrint()
     nctools.ncout_surf(basename+'.surf', longitude, latitude, basis_function, surface_albedo)
     nctools.ncout2d(   basename+'.tstar', 0, 0, atm.ts, 'tstar', longname="Surface Temperature", units='K')
     nctools.ncout2d(   basename+'.pstar', 0, 0, atm.ps, 'pstar', longname="Surface Pressure", units='PA')
     nctools.ncout2d(   basename+'.szen', 0, 0, zenith_angle, 'szen', longname="Solar zenith angle", units='Degrees')
     nctools.ncout2d(   basename+'.stoa', 0, 0, atm.toa_heating, 'stoa', longname="Solar Irradiance at TOA", units='WM-2')
+
+
     # T, P + volatiles
     nctools.ncout3d(basename+'.t', 0, 0,   atm.p,  atm.tmp, 't', longname="Temperature", units='K')
     nctools.ncout3d(basename+'.tl', 0, 0,  atm.pl, atm.tmpl, 'tl', longname="Temperature", units='K')
     nctools.ncout3d(basename+'.p', 0, 0,   atm.p,  atm.p, 'p', longname="Pressure", units='PA')
-    nctools.ncout3d(basename+'.q', 0, 0,   atm.p,  molar_mass['H2O'] / atm.mu * atm.x_gas["H2O"], 'q', longname="q", units='kg/kg') 
+    h2o_mmr = molar_mass['H2O'] / atm.mu * atm.x_gas["H2O"]
+    nctools.ncout3d(basename+'.q', 0, 0,   atm.p,  h2o_mmr, 'q', longname="q", units='kg/kg') 
 
     allowed_vols = {"CO2", "O3", "N2O", "CO", "CH4", "O2", "NO", "SO2", "NO2", "NH3", "HNO3", "N2", "H2", "He", "OCS"}
     for vol in atm.vol_list.keys():
@@ -131,7 +134,7 @@ def radCompSoc(atm, dirs, recalc, calc_cf=False, rscatter=False):
             vol_lower = str(vol).lower()
             nctools.ncout3d(basename+'.'+vol_lower, 0, 0, atm.p,  molar_mass[vol] / atm.mu * atm.x_gas[vol], vol_lower, longname=vol, units='kg/kg') 
 
-    enablePrint()
+    # enablePrint()
    
     s = " "
 
@@ -169,16 +172,17 @@ def radCompSoc(atm, dirs, recalc, calc_cf=False, rscatter=False):
 
 
     # Open netCDF files produced by SOCRATES
-    ncfile1  = net.Dataset('currentsw.vflx')
-    ncfile2  = net.Dataset('currentsw.sflx')
-    ncfile3  = net.Dataset('currentsw.dflx')
-    ncfile4  = net.Dataset('currentsw.uflx')
-    ncfile5  = net.Dataset('currentsw.nflx')
-    ncfile6  = net.Dataset('currentsw.hrts')
-    ncfile7  = net.Dataset('currentlw.dflx')
-    ncfile8  = net.Dataset('currentlw.nflx')
-    ncfile9  = net.Dataset('currentlw.uflx')
-    ncfile10 = net.Dataset('currentlw.hrts')
+    ncfile1  = net.Dataset('currentsw.vflx')  # direct + diffuse
+    ncfile2  = net.Dataset('currentsw.sflx')  # direct
+    ncfile3  = net.Dataset('currentsw.dflx')  # diffuse 
+    ncfile4  = net.Dataset('currentsw.uflx')  # upward
+    ncfile5  = net.Dataset('currentsw.nflx')  # net
+    ncfile6  = net.Dataset('currentsw.hrts')  # heating rate
+
+    ncfile7  = net.Dataset('currentlw.dflx')  # diffuse
+    ncfile8  = net.Dataset('currentlw.nflx')  # net
+    ncfile9  = net.Dataset('currentlw.uflx')  # upward
+    ncfile10 = net.Dataset('currentlw.hrts')  # heating rate
     if calc_cf == True:
         ncfile11 = net.Dataset('currentlw_cff.cff')
         ncfile12 = net.Dataset('currentlw.cff')
@@ -196,7 +200,6 @@ def radCompSoc(atm, dirs, recalc, calc_cf=False, rscatter=False):
     if calc_cf == True:
         cff    = ncfile11.variables['cff'] # Contribution function (flux, sum)
         cff_i  = ncfile12.variables['cff'] # Contribution function (channel, plev, lat, lon)
-
 
     ##### Fluxes
 

--- a/utils/atmosphere_column.py
+++ b/utils/atmosphere_column.py
@@ -91,7 +91,7 @@ class atmos:
 
         self.albedo_s   	= 0.0 							# surface albedo
         self.albedo_pl   	= 0.175 						# Bond albedo (scattering)
-        self.zenith_angle  	= 54.55							# solar zenith angle, Hamano+15 (arccos(1/sqrt(3) = 54.74), Wordsworth+ 10: 48.19 (arccos(2/3)), see Cronin 14 (mu = 0.58 -> theta = arccos(0.58) = 54.55) for definitions
+        self.zenith_angle  	= 54.74							# solar zenith angle, Hamano+15 (arccos(1/sqrt(3) = 54.74), Wordsworth+ 10: 48.19 (arccos(2/3)), see Cronin 14 (mu = 0.58 -> theta = arccos(0.58) = 54.55) for definitions
 
         self.planet_mass    = pl_mass
         self.planet_radius  = pl_radius


### PR DESCRIPTION
Resolves #27 .

Once the atmosphere reached sufficiently low temperatures, condensible vapours would begin condensing and change the surface pressure, which required that the `atmos` object be re-initialised in `general_adiabat()`. This was being done without ensuring that `atm.toa_heating` was being conserved, so it was being set to 0 W/m2 (the default value).

The fix is to simply make sure that `atm.toa_heating` is being conserved.