### PR TITLE
Fix to height integration

### DIFF
--- a/utils/height.py
+++ b/utils/height.py
@@ -32,13 +32,14 @@ def AtmosphericHeight(atm, m_planet, r_planet):
             mean_molar_mass += phys.molar_mass[vol]*atm.x_gas[vol][n]
 
         # Temperature below present height
-        T_mean_below    = np.mean(atm.tmp[n:])
+        # T_mean_below    = np.mean(atm.tmp[n:])
 
         # # Direction calculation
         # z_profile[n] = - R_gas * T_mean_below * np.log(atm.p[n]/P_s) / ( mean_molar_mass * grav_s )
 
         # Integration
-        dz = - phys.R_gas * T_mean_below * np.log(atm.p[n+1]/atm.p[n]) / (mean_molar_mass*grav_z)
+        # dz = - phys.R_gas * T_mean_below * np.log(atm.p[n+1]/atm.p[n]) / (mean_molar_mass*grav_z)
+        dz = phys.R_gas * atm.tmp[n] / (mean_molar_mass * grav_z * atm.p[n]) * (atm.p[n] - atm.p[n+1]) 
         
         # Next height
         z_profile[n+1] = z_profile[n] + dz


### PR DESCRIPTION
The previous formulation for calculating the cell heights from the other quantities (pressure, gravity, etc.) was incorrect. It comes from a derivation I made a few months ago which had a mistake in it. 

Comparing the p-z profile against that from Earth measurements showed significant deviation from the "true" profile when using the previous formulation, but now they match up very well. This is still not perfect, since in theory the gravity ODE and the hydrostatic ODE should be integrated as coupled equations, but doing so would be very expensive and certainly overkill.

The model still replicates the runaway greenhouse OLR curve, and still yields a net cooling flux for an Earth-like case initialised with a magma ocean. Obtaining the correct cell heights is important in AGNI for calculating heating rates, but in AEOLUS it's mostly useful for accurately calculating spectra.